### PR TITLE
Argument validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"image"
 	"os"
 	"time"
@@ -45,6 +46,12 @@ func draw(img image.Image) {
 }
 
 func main() {
+	if len(os.Args) != 2 {
+		fmt.Printf("Usage: %s <filename>\n\n", os.Args[0])
+		fmt.Println("Close the image with <ESC>.")
+		os.Exit(1)
+	}
+
 	img, err := load(os.Args[len(os.Args)-1])
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The panic was a little jarring, so I added a simple validator.

```
$ pxl
panic: open pxl: no such file or directory

goroutine 1 [running]:
panic(0x16c3e0, 0xc82007a330)
    /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
main.main()
    /Users/dcam/gopath/src/github.com/ichinaski/pxl/main.go:50 +0xb2
```

```
$ ./pxl
Usage: ./pxl <filename>

Close the image with <ESC>.
```
