### PR TITLE
make pxl useable as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ You will need to have [Go](https://golang.org) installed and configured in your 
 
 Close the image with `<ESC>`.
 
+### Library
+
+```go
+package main
+
+import "github.com/ichinaski/pxl"
+
+func main() {
+  fImg, _ := os.Open("someimage.jpg")
+  defer fImg.Close()
+  img, _, _ := image.Decode(fImg1)
+
+
+  pxl.Init()
+  defer pxl.Close()
+  Display(img)
+}
+```
+
 ### Disclaimer
 
 You may want to squint your eyes or take a few steps backwards when looking at the output.

--- a/color.go
+++ b/color.go
@@ -1,4 +1,4 @@
-package main
+package pxl
 
 import "image/color"
 

--- a/color_test.go
+++ b/color_test.go
@@ -1,4 +1,4 @@
-package main
+package pxl
 
 import (
 	"image/color"

--- a/image.go
+++ b/image.go
@@ -1,4 +1,4 @@
-package main
+package pxl
 
 import (
 	"image"

--- a/image_test.go
+++ b/image_test.go
@@ -1,4 +1,4 @@
-package main
+package pxl
 
 import "testing"
 

--- a/main.go
+++ b/main.go
@@ -1,71 +1,9 @@
-package main
+package pxl
 
 import (
 	"fmt"
-	"image"
 	"os"
-	"time"
-
-	_ "image/jpeg"
-	_ "image/png"
-
-	"github.com/nsf/termbox-go"
 )
-
-func draw(img image.Image) {
-	// Get terminal size and cursor width/height ratio
-	width, height, whratio := canvasSize()
-
-	bounds := img.Bounds()
-	imgW, imgH := bounds.Dx(), bounds.Dy()
-
-	imgScale := scale(imgW, imgH, width, height, whratio)
-
-	// Resize canvas to fit scaled image
-	width, height = int(float64(imgW)/imgScale), int(float64(imgH)/(imgScale*whratio))
-
-	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
-	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
-			// Calculate average color for the corresponding image rectangle
-			// fitting in this cell. We use a half-block trick, wherein the
-			// lower half of the cell displays the character ▄, effectively
-			// doubling the resolution of the canvas.
-			startX, startY, endX, endY := imgArea(x, y, imgScale, whratio)
-
-			r, g, b := avgRGB(img, startX, startY, endX, (startY+endY)/2)
-			colorUp := termbox.Attribute(termColor(r, g, b))
-
-			r, g, b = avgRGB(img, startX, (startY+endY)/2, endX, endY)
-			colorDown := termbox.Attribute(termColor(r, g, b))
-
-			termbox.SetCell(x, y, '▄', colorDown, colorUp)
-		}
-	}
-	termbox.Flush()
-}
-
-func display(image string) {
-	img, err := load(image)
-	if err != nil {
-		panic(err)
-	}
-
-	draw(img)
-
-	for {
-		switch ev := termbox.PollEvent(); ev.Type {
-		case termbox.EventKey:
-			if ev.Key == termbox.KeyEsc || ev.Ch == 'q' {
-				return
-			}
-		case termbox.EventResize:
-			draw(img)
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
-}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -74,14 +12,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	err := termbox.Init()
-	if err != nil {
-		panic(err)
-	}
-	defer termbox.Close()
-	termbox.SetOutputMode(termbox.Output256)
-
+	Init()
+	defer Close()
 	for i := 1; i < len(os.Args); i++ {
-		display(os.Args[i])
+		DisplayFile(os.Args[i])
 	}
 }

--- a/pxl.go
+++ b/pxl.go
@@ -1,0 +1,83 @@
+package pxl
+
+import (
+	"fmt"
+	"image"
+	"time"
+
+	_ "image/jpeg"
+	_ "image/png"
+
+	"github.com/nsf/termbox-go"
+)
+
+func Draw(img image.Image) {
+	// Get terminal size and cursor width/height ratio
+	width, height, whratio := canvasSize()
+
+	bounds := img.Bounds()
+	imgW, imgH := bounds.Dx(), bounds.Dy()
+
+	imgScale := scale(imgW, imgH, width, height, whratio)
+
+	// Resize canvas to fit scaled image
+	width, height = int(float64(imgW)/imgScale), int(float64(imgH)/(imgScale*whratio))
+
+	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			// Calculate average color for the corresponding image rectangle
+			// fitting in this cell. We use a half-block trick, wherein the
+			// lower half of the cell displays the character ▄, effectively
+			// doubling the resolution of the canvas.
+			startX, startY, endX, endY := imgArea(x, y, imgScale, whratio)
+
+			r, g, b := avgRGB(img, startX, startY, endX, (startY+endY)/2)
+			colorUp := termbox.Attribute(termColor(r, g, b))
+
+			r, g, b = avgRGB(img, startX, (startY+endY)/2, endX, endY)
+			colorDown := termbox.Attribute(termColor(r, g, b))
+
+			termbox.SetCell(x, y, '▄', colorDown, colorUp)
+		}
+	}
+	termbox.Flush()
+}
+
+func DisplayFile(image string) {
+	img, err := load(image)
+	if err != nil {
+		panic(err)
+	}
+	Display(img)
+}
+
+func Display(img image.Image) {
+	Draw(img)
+
+	for {
+		switch ev := termbox.PollEvent(); ev.Type {
+		case termbox.EventKey:
+			if ev.Key == termbox.KeyEsc || ev.Ch == 'q' {
+				return
+			}
+		case termbox.EventResize:
+			Draw(img)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func Init() {
+	fmt.Println("FOO")
+	err := termbox.Init()
+	if err != nil {
+		panic(err)
+	}
+	termbox.SetOutputMode(termbox.Output256)
+}
+
+func Close() {
+	termbox.Close()
+}


### PR DESCRIPTION
#### Problem

I wanted to be able to run the go-tour things in the console and see the image outputs, 

#### Solution

I saw your code, and banged on it until I could use it as a [library](https://github.com/karlhungus/lib_pxl), this seemed somewhat useful, so I thought maybe you'd want the code, so here it is.

I'm totally cool if you don't think this is useful as a library (requires people to hit ESC to get out of viewing the image...)

@ichinaski 

